### PR TITLE
REST Service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.cache/
+.idea/
+build/
+dist/
+*.egg-info/
+
+*.py[co]
+__pycache__/
+.git/
+.gitignore
+
+Makefile
+requirements-dev.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:alpine
+
+ARG BUILD_DATE
+ARG SOURCE_COMMIT
+ARG VERSION
+
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.description="Reduce Arabic strings to their rasm, ie remove vocalization and other diacritics." \
+      org.label-schema.name="rasmify" \
+      org.label-schema.version=$VERSION \
+      org.label-schema.usage="/src/README.rst" \
+      org.label-schema.url="https://github.com/telota/rasmipy" \
+      org.label-schema.vcs-url="https://github.com/telota/rasmipy" \
+      org.label-schema.docker.cmd="docker run --rm telota/rasmify" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-ref=$SOURCE_COMMIT
+
+ENV PORT=80
+EXPOSE 80
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["rasmify-rest-service"]
+
+COPY . /src
+RUN cd /src \
+ && apk add --no-cache tini \
+ && pip install --no-cache-dir .[rest-api]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,76 @@
+.DEFAULT_GOAL := help
+
+REPO_NAME = telota/rasmify
+VERSION = $(shell grep "version=" setup.py | cut -f2 -d"'")
+IMAGE_NAME = $(REPO_NAME):$(VERSION)
+SOURCE_COMMIT = $(shell git rev-parse HEAD)
+BUILD_DATE = "$(shell date --rfc-3339 seconds)"
+BUILD_ARGS = --build-arg BUILD_DATE=$(BUILD_DATE) --build-arg SOURCE_COMMIT=$(SOURCE_COMMIT) --build-arg VERSION=$(VERSION)
+
+define PRINT_HELP_PYSCRIPT
+import re, sys
+
+for line in sys.stdin:
+	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
+	if match:
+		target, help = match.groups()
+		print("%-20s %s" % (target, help))
+endef
+export PRINT_HELP_PYSCRIPT
+
+.PHONY: help
+help:
+	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+
+.PHONY: image
+image: ## build the Docker image
+	docker build $(BUILD_ARGS) -t $(IMAGE_NAME) .
+
+.PHONY: run-docker-service
+run-docker-service: image ## run the REST service as Docker container listening on port 8000
+	docker run --rm -p 8000:80 $(IMAGE_NAME)
+
+.PHONY: clean
+clean: clean-build clean-pyc clean-test ## clean all atrifacts
+
+.PHONY: clean-build
+clean-build: ## remove build artifacts
+	rm -fr build/
+	rm -fr dist/
+	rm -fr .eggs/
+	find . -name '*.egg-info' -exec rm -fr {} +
+	find . -name '*.egg' -exec rm -f {} +
+
+.PHONY: clean-pyc
+clean-pyc: ## remove Python file artifacts
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
+
+.PHONY: clean-test
+clean-test: ## remove test and coverage artifacts
+	rm -fr .tox/
+	rm -f .coverage
+	rm -fr htmlcov/
+
+.PHONY: lint
+lint: ## check style with flake8
+	flake8 rasmipy tests setup.py
+
+.PHONY: tests
+tests: ## run the tests
+	tox
+
+.PHONY: release
+release: test clean ## CAREFUL! release on GitHub and the PyPI
+	git tag -f $(VERSION)
+	git tag -f latest
+	git push origin master
+	git push -f origin $(VERSION)
+	git push -f origin latest
+	python setup.py sdist bdist_wheel upload
+
+.PHONY: install
+install: clean ## install the package to the active Python's site-packages
+	python setup.py install

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,10 @@ To run a REST service:
 
     $ rasmify-rest-service
 
+Or in a Docker container (with the HTTP port mapped to 8000):
+
+    $ docker run --rm -p 8000:80 telota/rasmify
+
 Example GET request:
 
     $ curl http://localhost:8000/?text=ءَاتَيۡنَا
@@ -46,7 +50,6 @@ Example POST request:
     $ curl -H "Content-Type: text/plain" -d 'ءَاتَيۡنَا' -X POST http://localhost:8000/
 
 There are two environment variables that can be used to configure the service:
-
 
 ``PORT`` defines the port that the server listens, defaults to ``8000``.
 ``MAX_GET_PARAMETER_LENGTH`` defines the allowed maximum length of GET requests,
@@ -59,9 +62,10 @@ Resources
 - About the rasm writing script: https://en.wikipedia.org/wiki/Rasm
 - Code repository: https://github.com/telota/rasmipy
 - On the Python Package Index: https://pypi.python.org/pypi/rasmipy
+- On the Docker Hub: https://hub.docker.com/r/telota/rasmify
 - PHP implementation: https://packagist.org/packages/telota/rasmify
 - Javascript implementation: https://github.com/telota/rasmify.js
-- Web demo: https://telota.github.io/rasmify.js/demo/
+- Javascript web demo: https://telota.github.io/rasmify.js/demo/
 
 
 Contributing

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,32 @@ From the sources:
 
     $ python setup.py install
 
+With the optional REST interface:
+
+    $ pip install ramsipy[rest-api]
+
+REST API
+--------
+
+To run a REST service:
+
+    $ rasmify-rest-service
+
+Example GET request:
+
+    $ curl http://localhost:8000/?text=ءَاتَيۡنَا
+
+Example POST request:
+
+    $ curl -H "Content-Type: text/plain" -d 'ءَاتَيۡنَا' -X POST http://localhost:8000/
+
+There are two environment variables that can be used to configure the service:
+
+
+``PORT`` defines the port that the server listens, defaults to ``8000``.
+``MAX_GET_PARAMETER_LENGTH`` defines the allowed maximum length of GET requests,
+defaults to ``1024``.
+
 
 Resources
 ---------

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+echo "------ HOOK START - BUILD -------"
+
+BUILD_DATE="$(date --rfc-3339 seconds)"
+VERSION=$(grep "version=" setup.py | cut -f2 -d"'")
+printenv
+docker build --build-arg BUILD_DATE="${BUILD_DATE}" --build-arg SOURCE_COMMIT="${GIT_SHA1}" --build-arg VERSION=$VERSION -t $IMAGE_NAME .
+
+echo "------ HOOK END - BUILD -------"

--- a/rasmipy/rest_service.py
+++ b/rasmipy/rest_service.py
@@ -1,12 +1,36 @@
 import os
+from signal import signal, SIGINT, SIGTERM
 
 import hug
 
 from rasmipy import rasmify
 
 
+# configuration
+
+
 listen_port = int(os.getenv('PORT', 8000))
 get_text_type = hug.types.shorter_than(int(os.getenv('MAX_GET_PARAMETER_LENGTH', 1024)))
+
+
+# signal handling
+
+
+def sigint_handler(signum, frame):
+    print('Keyboard interrupt.')
+    raise SystemExit(0)
+
+
+def sigterm_handler(signum, frame):
+    print('Received SIGTERM.')
+    raise SystemExit(0)
+
+
+signal(SIGINT, sigint_handler)
+signal(SIGTERM, sigterm_handler)
+
+
+# endpoints
 
 
 @hug.get('/')
@@ -17,6 +41,9 @@ def rasmify_get(text: get_text_type):
 @hug.post('/')
 def rasmify_post(body: hug.types.text):
     return rasmify(body)
+
+
+# service app
 
 
 def serve():

--- a/rasmipy/rest_service.py
+++ b/rasmipy/rest_service.py
@@ -1,0 +1,23 @@
+import os
+
+import hug
+
+from rasmipy import rasmify
+
+
+listen_port = int(os.getenv('PORT', 8000))
+get_text_type = hug.types.shorter_than(int(os.getenv('MAX_GET_PARAMETER_LENGTH', 1024)))
+
+
+@hug.get('/')
+def rasmify_get(text: get_text_type):
+    return rasmify(text)
+
+
+@hug.post('/')
+def rasmify_post(body: hug.types.text):
+    return rasmify(body)
+
+
+def serve():
+    hug.API(__name__).http.serve(listen_port, display_intro=False)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,10 @@ setup(
     name='rasmipy',
     version='0.1',
     python_requires='>=3',
+    extras_require={'rest-api': ['hug']},
     packages=['rasmipy'],
+    entry_points={'console_scripts':
+                  ['rasmify-rest-service=rasmipy.rest_service:serve [rest-api]']},
     url='https://github.com/telota/rasmipy',
     license='LGPLv3',
     author='Oliver Pohl, Frank Sachsenheim',


### PR DESCRIPTION
this adds the rest service.

it works technically, but i had trouble testing proper functionality. in particular my pastes of ltr-strings from the clipboard into the shell to test the `curl` commands ended up reversed.

once this is answered satisfyingly, that's left to do:

- create a Automated Build for the Docker repo `telota/rasmify` (with only tags triggering a build)
- bump the version to 0.2
- `make release`
- :-D

please be very careful with my interface design decisions. i decided against a versioned api, as i can't imagine any extension. or they would result in more that that one 'root' endpoint.

btw, *hug* is really cool regarding its capabilities and flexibilty, but the documentation doesn't complement that well. that takes a lot of the momentum to make a rest service within the blink of an eye.

Closes #6.